### PR TITLE
Bump services and update identifier port mapping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml:docker-compose.override.yml

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml:docker-compose.override.yml
+COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,14 +1,14 @@
-version: '3.7'
+version: "3.7"
 
 services:
   identifier:
-    restart: "no"
     ports:
-      - 80:80
+      - "90:80"
+    restart: "no"
 
   mocklogin:
-    image: lblod/mock-login-service:0.3.1
-    
+    image: lblod/mock-login-service:0.4.0
+
   dispatcher:
     restart: "no"
 
@@ -39,4 +39,3 @@ services:
     
   subsidies-consumer:
     restart: "no"
-    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     logging: *default-logging
 
   virtuoso:
-    image: redpencil/virtuoso:1.0.0
+    image: redpencil/virtuoso:1.2.0-rc.1
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/graphs/public"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     logging: *default-logging
 
   identifier:
-    image: semtech/mu-identifier:1.10.0
+    image: semtech/mu-identifier:1.10.1
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
This PR adjusts some parts of the `docker-compose.dev.yml` file:
* Bump `mock-login` service to `v0.4.0`
* Adjust `identifier` port mapping
* Add `.env.example` similar to what `app-organization-portal` does
* Bump `virtuoso` to `v1.2.0-rc.1`
    - `app-lpdc-digitaal-loket` has been running this version for 3 months without any issues. It has undergone testing by us in addition to the new Kunlabora team that has taken over the project. We have also gone to production with this virtuoso version, and so far, all looks good.