### PR TITLE
Bump migrations service to v0.9.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     logging: *default-logging
 
   migrations:
-    image: semtech/mu-migrations-service:0.8.0
+    image: semtech/mu-migrations-service:0.9.0
     links:
       - virtuoso:database
     volumes:


### PR DESCRIPTION
## Description

Bump the migrations service from `v0.8.0` to `v0.9.0`.

 ## Type of change

 - Maintenance change

 ## Related services

 - `migrations`

 ## How to test

Delete the existing db that was obtained from running the migrations on the previous version:
```
rm -rf data && git checkout data
```
and run the migrations again.