### PR TITLE
feat: add economic actor to filtering

### DIFF
--- a/config/migrations/2024/20240715104628-add-verenigingen-criterion.sparql
+++ b/config/migrations/2024/20240715104628-add-verenigingen-criterion.sparql
@@ -1,0 +1,47 @@
+PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>
+PREFIX subsidie: <http://data.vlaanderen.be/ns/subsidie#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX lblod: <http://data.lblod.info/id/conceptscheme/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Create ACMIDMOrganisationClassification concept scheme
+    <http://data.lblod.info/id/conceptscheme/ACMIDMOrganisationClassification> a <http://www.w3.org/2004/02/skos/core#ConceptScheme>;
+      mu:uuid "586e1a3d-56ef-424b-862d-2123d8b7189f" ;
+      skos:prefLabel "ACM/IDM OrganisatieClassificatie"@nl ;
+      skos:prefLabel "ACM/IDM OrganisationClassification"@en ;
+      skos:definition "Lijst van type organisaties binnen ACM/IDM"@nl .
+
+    # Add concept-scheme for economische actoren
+    <http://data.lblod.info/id/concept/c6157470-9fb3-4e8d-a9b7-8737dbfa3642>
+      mu:uuid "c6157470-9fb3-4e8d-a9b7-8737dbfa3642" ;
+      rdf:type skos:Concept , ext:OrganizationClassificationCode;
+      skos:prefLabel "Economische actor"@nl ;
+      skos:prefLabel "Economic actor"@en ;
+      skos:definition "Economische actoren binnen ACM/IDM"@nl ;
+      skos:topConceptOf lblod:ACMIDMOrganisationClassification ;
+      skos:inScheme lblod:ACMIDMOrganisationClassification .
+
+    # Add new criterion for economische actoren (verenigingen)
+    <http://data.lblod.info/id/criterions/28fe1648-dd25-4772-b5e9-0eed4e8f4b90>
+      a <http://data.europa.eu/m8g/Criterion> ;
+      mu:uuid "28fe1648-dd25-4772-b5e9-0eed4e8f4b90" ;
+      <http://purl.org/dc/terms/title> "Subsidiemaatregelaanbod: doelgroep economische actoren" ;
+      <http://data.europa.eu/m8g/fulfilledByRequirementGroup> <http://data.lblod.info/id/requirement-groups/8b0a601a-2432-4c0a-9363-b869d4632c54> .
+
+    <http://data.lblod.info/id/requirement-groups/8b0a601a-2432-4c0a-9363-b869d4632c54>
+      a <http://data.europa.eu/m8g/RequirementGroup> ;
+      mu:uuid "8b0a601a-2432-4c0a-9363-b869d4632c54" ;
+      <http://purl.org/dc/terms/description> "Criteriumgroep: de organisatie moet voldoen aan de vereisten van een economische actor." ;
+      <http://data.europa.eu/m8g/hasCriterionRequirement> <http://data.lblod.info/id/criterion-requirement/27499267-9fc8-4fa5-9ac6-d1b553ab342e> .
+
+    <http://data.lblod.info/id/criterion-requirement/27499267-9fc8-4fa5-9ac6-d1b553ab342e>
+     a <http://data.europa.eu/m8g/CriterionRequirement> ;
+     mu:uuid "27499267-9fc8-4fa5-9ac6-d1b553ab342e" ;
+     <http://purl.org/dc/terms/description> "Criteriumvereiste: de organisatie heeft classificatiecode economische actor." ;
+     lblodSubsidie:isSatisfiableBy <http://data.lblod.info/id/concept/c6157470-9fb3-4e8d-a9b7-8737dbfa3642> .
+  }
+}

--- a/config/migrations/2024/20240715104628-add-verenigingen-criterion.sparql
+++ b/config/migrations/2024/20240715104628-add-verenigingen-criterion.sparql
@@ -20,7 +20,6 @@ INSERT DATA {
       mu:uuid "c6157470-9fb3-4e8d-a9b7-8737dbfa3642" ;
       rdf:type skos:Concept , ext:OrganizationClassificationCode;
       skos:prefLabel "Economische actor"@nl ;
-      skos:prefLabel "Economic actor"@en ;
       skos:definition "Economische actoren binnen ACM/IDM"@nl ;
       skos:topConceptOf lblod:ACMIDMOrganisationClassification ;
       skos:inScheme lblod:ACMIDMOrganisationClassification .

--- a/config/migrations/2024/20240829173249-create-combined-filter-concept-scheme.sparql
+++ b/config/migrations/2024/20240829173249-create-combined-filter-concept-scheme.sparql
@@ -1,0 +1,31 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/conceptscheme/CombinedOrganisationClassification> a skos:ConceptScheme ;
+      mu:uuid "fb16066b-170e-4e86-9df3-83f33d52fccd" ;
+      skos:prefLabel "Gecombineerde Organisatie Classificatie"@nl . # TODO: better naming
+
+    ?concept skos:inScheme <http://data.lblod.info/id/conceptscheme/CombinedOrganisationClassification> .
+    ?concept skos:topConceptOf <http://data.lblod.info/id/conceptscheme/CombinedOrganisationClassification> .
+  }
+}
+WHERE {
+  {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+      ?concept skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> .
+      ?concept skos:prefLabel ?label .
+      OPTIONAL { ?concept skos:definition ?definition }
+    }
+  }
+  UNION
+  {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+      ?concept skos:inScheme <http://data.lblod.info/id/conceptscheme/ACMIDMOrganisationClassification> .
+      ?concept skos:prefLabel ?label .
+      OPTIONAL { ?concept skos:definition ?definition }
+    }
+  }
+}

--- a/config/migrations/2024/20240829173249-create-combined-filter-concept-scheme.sparql
+++ b/config/migrations/2024/20240829173249-create-combined-filter-concept-scheme.sparql
@@ -6,7 +6,7 @@ INSERT {
   GRAPH <http://mu.semte.ch/graphs/public> {
     <http://data.lblod.info/id/conceptscheme/CombinedOrganisationClassification> a skos:ConceptScheme ;
       mu:uuid "fb16066b-170e-4e86-9df3-83f33d52fccd" ;
-      skos:prefLabel "Gecombineerde Organisatie Classificatie"@nl . # TODO: better naming
+      skos:prefLabel "Gecombineerde Organisatie Classificatie van economische actor en bestuurseenheden"@nl .
 
     ?concept skos:inScheme <http://data.lblod.info/id/conceptscheme/CombinedOrganisationClassification> .
     ?concept skos:topConceptOf <http://data.lblod.info/id/conceptscheme/CombinedOrganisationClassification> .

--- a/config/search-query/filter-form.ttl
+++ b/config/search-query/filter-form.ttl
@@ -47,7 +47,9 @@ ext:typeBestuurF a form:Field ;
     sh:path searchSubsidie:typeBestuur;
     form:displayType displayTypes:conceptSchemeSelector ;
     search:emberQueryParameterKey "bestuursType" ;
-    form:options  """{"conceptScheme":"http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode"}""" ;
+    # form:options  """{"conceptScheme":"http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode"}""" ;
+    form:options  """{"conceptScheme":"http://data.lblod.info/id/conceptscheme/ACMIDMOrganisationClassification"}""" ;
+    # form:options  """{"conceptScheme":"http://data.lblod.info/id/conceptscheme/CombinedOrganisationClassification"}""" ;
     form:help "vb. Gemeente, OCMW" ;
     sh:order 20;
     sh:group ext:applicationPg .
@@ -78,12 +80,3 @@ ext:subsidieStatusF a form:Field ;
     form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/f7274d7f-31d5-4b02-aca8-b96481115651"}""" ;
     sh:order 30;
     sh:group ext:applicationPg .
-
-
-
-
-    
-
-
-    
-    

--- a/config/search-query/filter-form.ttl
+++ b/config/search-query/filter-form.ttl
@@ -47,9 +47,7 @@ ext:typeBestuurF a form:Field ;
     sh:path searchSubsidie:typeBestuur;
     form:displayType displayTypes:conceptSchemeSelector ;
     search:emberQueryParameterKey "bestuursType" ;
-    # form:options  """{"conceptScheme":"http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode"}""" ;
-    form:options  """{"conceptScheme":"http://data.lblod.info/id/conceptscheme/ACMIDMOrganisationClassification"}""" ;
-    # form:options  """{"conceptScheme":"http://data.lblod.info/id/conceptscheme/CombinedOrganisationClassification"}""" ;
+    form:options  """{"conceptScheme":"http://data.lblod.info/id/conceptscheme/CombinedOrganisationClassification"}""" ;
     form:help "vb. Gemeente, OCMW" ;
     sh:order 20;
     sh:group ext:applicationPg .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     logging: *default-logging
 
   form-data-management:
-    image: lblod/form-data-management-service:0.0.3
+    image: lblod/form-data-management-service:0.1.0
     volumes:
       - ./config/search-query:/share/search-query
     labels:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-subsidiedatabank",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app-subsidiedatabank",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "ISC",
       "devDependencies": {
         "release-it": "^17.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-subsidiedatabank",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Bootstrap a mu.semte.ch microservices environment in three easy steps.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## ID
DGS-293

## Description
Add the economic actor to the filtering menu's by creating a combined concept-scheme containing the regular bestuurseenheden and the new economic actor.

## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Maintanance

## How to setup
...

## How to test
- Use https://github.com/lblod/form-data-management-service/pull/1 for the form-data-management-service with:
```
  form-data-management:
    # image: lblod/form-data-management-service:0.0.3
    image: semtech/mu-javascript-template:1.6.0
    ports:
      - 8888:80
      - 9229:9229
    environment:
      NODE_ENV: "development"
    volumes:
      - ./config/search-query:/share/search-query
      - /absolute/path/to/your/sources/:/app/ # link to the form-data-management-service PR
```
- Run the setup, go to the frontend and verify that the 'economische actoren' are now part of the filtering.