### PR TITLE
Add and show organization filter

### DIFF
--- a/config/migrations/2024/20241015174842-new-economische-actor-concept-scheme.sparql
+++ b/config/migrations/2024/20241015174842-new-economische-actor-concept-scheme.sparql
@@ -1,0 +1,11 @@
+
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT DATA {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+        <http://data.lblod.info/id/conceptscheme/EconomischeActoren> a skos:ConceptScheme;
+        mu:uuid "5e1c1d4a-3146-4a6b-bfb6-ce23c73c7f8c";
+        skos:prefLabel "Economische Actoren".
+    }
+}

--- a/config/migrations/2024/20241015175324-db-cleanup-add-organizations-to-concept-scheme.sparql
+++ b/config/migrations/2024/20241015175324-db-cleanup-add-organizations-to-concept-scheme.sparql
@@ -1,0 +1,34 @@
+PREFIX cleanup: <http://mu.semte.ch/vocabularies/ext/cleanup/>
+PREFIX mu:      <http://mu.semte.ch/vocabularies/core/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/job/id/7dafe8eb-de89-49c4-9bac-bcaf0222fa3c> a cleanup:Job;
+      mu:uuid "7dafe8eb-de89-49c4-9bac-bcaf0222fa3c";
+      dcterms:title "Compensating missing rdf:Type on some formNodes in some subsidy forms";
+      cleanup:randomQuery """
+        INSERT {
+          GRAPH ?g{
+            ?organization <http://www.w3.org/2004/02/skos/core#inScheme> <http://data.lblod.info/id/conceptscheme/EconomischeActoren>
+          }
+        } WHERE {
+          GRAPH ?g {
+            ?organization a <http://www.w3.org/ns/org#Organization>.
+            
+            # We dont want orgs like erediensten in our list at the moment.
+            FILTER NOT EXISTS {
+              ?organization a ?otherType.
+              FILTER (?otherType NOT IN (<http://www.w3.org/ns/org#Organization>))
+            }
+
+            # Ensure the organization does not already have the scheme attached
+            FILTER NOT EXISTS {
+              ?organization <http://www.w3.org/2004/02/skos/core#inScheme> <http://data.lblod.info/id/conceptscheme/EconomischeActoren>
+            }
+          }
+        }
+      """;
+      cleanup:cronPattern "0 * * * *". # Runs hourly
+    }
+  }

--- a/config/search-query/filter-form.ttl
+++ b/config/search-query/filter-form.ttl
@@ -21,6 +21,7 @@
     form:includes ext:typeSubsidieF;
     form:includes ext:typeBestuurF;
     form:includes ext:organizationsF;
+    form:includes ext:economischeActorenF;
     form:includes ext:aanvraagDatumF;
     form:includes ext:subsidieStatusF.
 
@@ -58,8 +59,18 @@ ext:organizationsF a form:Field ;
     form:displayType displayTypes:conceptSchemeSelector ;
     search:emberQueryParameterKey "organizations" ;
     form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083"}""" ;
-    form:help "vb. Gemeente Hasselt, OCMW Gent" ;
+    form:help "vb. Gemeente Hasselt, Gemeente Antwerpen" ;
     sh:order 20;
+    sh:group ext:applicationPg .
+
+ext:economischeActorenF a form:Field ;
+    sh:name "Economische Actoren" ;
+    sh:path searchSubsidie:organizations;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    search:emberQueryParameterKey "economischeActoren" ;
+    form:options  """{"conceptScheme":"http://data.lblod.info/id/conceptscheme/EconomischeActoren"}""" ;
+    form:help "vb. Antwerp Pride" ;
+    sh:order 30;
     sh:group ext:applicationPg .
 
 ext:aanvraagDatumF a form:Field ;
@@ -67,7 +78,7 @@ ext:aanvraagDatumF a form:Field ;
     sh:path searchSubsidie:aanvraagDatum;
     form:displayType displayTypes:datePicker;
     search:emberQueryParameterKey "aanvraagDatum" ;
-    sh:order 30;
+    sh:order 40;
     sh:group ext:applicationPg .
 
 ext:subsidieStatusF a form:Field ;
@@ -76,5 +87,5 @@ ext:subsidieStatusF a form:Field ;
     form:displayType displayTypes:conceptSchemeMultiSelector ;
     search:emberQueryParameterKey "subsidieStatus" ;
     form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/f7274d7f-31d5-4b02-aca8-b96481115651"}""" ;
-    sh:order 30;
+    sh:order 50;
     sh:group ext:applicationPg .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,3 +50,6 @@ services:
 
   file:
     restart: "no"
+
+  db-cleanup:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,3 +157,10 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+
+  db-cleanup:
+    image: lblod/db-cleanup-service:0.5.0
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,9 +90,10 @@ services:
     logging: *default-logging
 
   form-data-management:
-    image: lblod/form-data-management-service:0.1.0
+    image: lblod/form-data-management-service:0.2.0
     volumes:
       - ./config/search-query:/share/search-query
+      - ./data/files/form-data-meta/:/data/
     labels:
       - "logging=true"
     restart: always
@@ -159,7 +160,7 @@ services:
     logging: *default-logging
 
   db-cleanup:
-    image: lblod/db-cleanup-service:0.5.0
+    image: lblod/db-cleanup-service:0.5.1
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
## ID
DGS-DL-6200

## Description
With the new addition of economische actoren, we also want to be able to filter on them. This PR adds a new filtering field and a db-cleanup query thats adds newly created organization to the concept scheme of the filtering dropdown

## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Maintanance