### PR TITLE
Add error handling for subsidies-consumer

### DIFF
--- a/config/subsidies-consumer/subsidy-attachments-dispatching/error.js
+++ b/config/subsidies-consumer/subsidy-attachments-dispatching/error.js
@@ -1,0 +1,25 @@
+import { uuid, sparqlEscapeString, sparqlEscapeUri, sparqlEscapeDateTime } from 'mu';
+import { updateSudo as update } from '@lblod/mu-auth-sudo';
+
+const errorType = 'http://redpencil.data.gift/id/error/subsidies-consumer'
+
+export async function createError(graph, message, correlationId){
+  const id = uuid();
+  const uri = errorType + '/' + id;
+  const created = new Date();
+
+  const queryError = `
+   ${service_config.prefixes}
+   INSERT DATA {
+    GRAPH ${sparqlEscapeUri(graph)}{
+      ${sparqlEscapeUri(uri)} a ${sparqlEscapeUri(errorType)};
+        mu:uuid ${id};
+        dct:created ${sparqlEscapeDateTime(created)};
+        oslc:message ${sparqlEscapeString(message)};
+        dct:identifier ${sparqlEscapeString(correlationId)}.
+    }
+   }
+  `;
+
+  await update(queryError);
+}

--- a/config/subsidies-consumer/subsidy-attachments-dispatching/file-processor.js
+++ b/config/subsidies-consumer/subsidy-attachments-dispatching/file-processor.js
@@ -12,8 +12,8 @@ const {
 const { createError } = require('./error');
 
 // Types of operations
-const DOWNLOAD_OPERATION = "download"
-const DELETE_OPERATION = "delete"
+const DOWNLOAD_OPERATION = "download";
+const DELETE_OPERATION = "delete";
 
 // Cookie necessary to download file from producer
 let cookie = null;
@@ -42,7 +42,7 @@ async function processFileDeltas(termObjects, fetch, operation) {
     // Process meta files (<data://)
     if (isMetaFile(item)) {
       if (operation === DOWNLOAD_OPERATION) {
-        downloadFile(item.object.replace('<data://', '<share://subsidies/'), fetch, correlationId);
+        await downloadFile(item.object.replace('<data://', '<share://subsidies/'), fetch, correlationId);
       } else if (operation === DELETE_OPERATION) {
         deleteFile(item.object.replace('<data://', '<share://subsidies/'), correlationId);
       }
@@ -51,7 +51,7 @@ async function processFileDeltas(termObjects, fetch, operation) {
     // Process attachments (<share://)
     else if (isAttachmentFile(item)) {
       if (operation === DOWNLOAD_OPERATION) {
-        downloadFile(item.subject, fetch, correlationId);
+        await downloadFile(item.subject, fetch, correlationId);
       } else if (operation === DELETE_OPERATION) {
         deleteFile(item.subject, correlationId);
       }
@@ -202,7 +202,7 @@ function isAttachmentFile(item) {
  * @returns {Promise} A promise representing the completion of directory creation.
  */
 async function createDirectories(filePath) {
-  await fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
 }
 
 /**


### PR DESCRIPTION
We want the errors to be saved to DB so we can deep dive if something goes wrong

## ID
DGS-432

## Description
We currently do not have an easy way to find out what went wrong when a file didnt get downloaded. this PR saves the errors to the DB

## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Maintanance

## How to setup
Setup as usual (consumer-producer)

## How to test
Make sure everything still downloads as usual, also try to create an error manually 
