### PR TITLE
Add new fusiebesturen to conceptscheme lists

### DIFF
--- a/config/migrations/2024/20241217204043-fusies/20241216200610-rename-merged-municipalities-and-ocmws.sparql
+++ b/config/migrations/2024/20241217204043-fusies/20241216200610-rename-merged-municipalities-and-ocmws.sparql
@@ -1,0 +1,35 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?organisation skos:prefLabel ?oldName.
+  }
+  GRAPH ?g {
+    ?person foaf:familyName ?oldFamilyName.
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?organisation skos:prefLabel ?newName.
+  }
+  GRAPH ?g {
+    ?person foaf:familyName ?newName.
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?organisation a besluit:Bestuurseenheid;
+                  skos:prefLabel ?oldName.
+  }
+  GRAPH ?g {
+    ?person foaf:member ?organisation;
+            foaf:familyName ?oldFamilyName.
+  }
+  VALUES (?organisation ?newName) {
+    (<http://data.lblod.info/id/bestuurseenheden/99da98a7a0087d3429b084ebfc4eb5d488c593790d4d5af7253982a2e21a6a5f> """Bilzen-Hoeselt""") # Bilzen -> Bilzen-Hoeselt (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/9ae900a5447b7d727ca6496910220d4389aba7f1869923f1bbf9729bdeca28e2> """Bilzen-Hoeselt""") # Bilzen => Bilzen-Hoeselt (OCMW)
+    (<http://data.lblod.info/id/bestuurseenheden/05099fa1f6524b8b994d86f61549455d2c00b2a956d5308683ac2d1f810fc729> """Tessenderlo-Ham""") # Ham -> Tessenderlo-Ham (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/42a43591e0db1dca9432f480f0f49f9bd4056c2b131e2fc997497130f5e099d0> """Tessenderlo-Ham""") # Ham -> Tessenderlo-Ham (OCMW)
+    (<http://data.lblod.info/id/bestuurseenheden/104f32d7fb8d4b8b61b71717301656f136fe046eabaf126fb3325896b5c2d625> """Tongeren-Borgloon""") # Tongeren -> Tongeren-Borgloon (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/ab684633d605d93dbbe6b9ea40667e2bcf03a0856cafe1825e95b7829ed502a3> """Tongeren-Borgloon""") # Tongeren -> Tongeren-Borgloon (OCMW)
+  }
+}

--- a/config/migrations/2024/20241217204043-fusies/20241217202352-add-fusiebesturen-to-filter-concepts.sparql
+++ b/config/migrations/2024/20241217204043-fusies/20241217202352-add-fusiebesturen-to-filter-concepts.sparql
@@ -1,0 +1,27 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit:	<http://data.vlaanderen.be/ns/besluit#> 
+PREFIX mu:	<http://mu.semte.ch/vocabularies/core/> 
+
+
+INSERT {
+  GRAPH ?g {
+    ?bestuurseenheid skos:topConceptOf <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> ;
+                      skos:inScheme <http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?bestuurseenheid a besluit:Bestuurseenheid ;
+                      mu:uuid ?uuid .
+    FILTER(?uuid IN (
+      "19483103-318e-435a-aa37-45e485406ee9",  # Beveren-Kruibeke-Zwijndrecht (Gemeente)
+      "1ca65d65-54ff-4b44-b750-bd70c91191af",  # Nazareth-De Pinte (Gemeente)
+      "add1e4eb-9ec7-4ea6-af82-335aa76b7d48",  # Pajottegem (Gemeente)
+      "b8bb293d-aa22-4b43-bda4-0b6af76e9493",  # Merelbeke-Melle (Gemeente)
+      "fd41f573-7d9a-4d9f-b7d0-d5b6114d1622",  # Beveren-Kruibeke-Zwijndrecht (OCMW)
+      "7d53f659-3a3b-44b1-9e77-3ea067678c0e",  # Nazareth-De Pinte (OCMW)
+      "650378e7-1bee-4737-91ff-5b20ac4623cf",  # Pajottegem (OCMW)
+      "5d94b2fd-60ee-4e56-a1f0-a586d596adf6"   # Merelbeke-Melle (OCMW)
+    ))
+  }
+}


### PR DESCRIPTION
## ID
DGS-425

## Description
To show the new fusiebesturen in the bestuurseenheden filter, we need to add them to the conceptscheme.

## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Maintanance

## How to setup
Setup as usual, make sure migrations ran. Restart form-data-management AFTER migrations finished

## How to test
go to app and check if (e.g. pajottegem) is in the bestuurseenheden dropdown filter list 
